### PR TITLE
Fixing SSH port bug

### DIFF
--- a/onestopsecurity.sh
+++ b/onestopsecurity.sh
@@ -22,7 +22,9 @@ housekeeping() {
 
 changesshport() {
     read -p "What port would you like to use for SSH (Ideally use an Ephemeral Port 32768-60999): " sshport
-    echo "Port $sshport" | sudo tee -a $sshconfig
+    #echo "Port $sshport" | sudo tee -a $sshconfig
+    #This will replace the current port in the SSH config to the user input
+    sed -i "s/.*Port .*/Port $sshport/" $sshconfig
 }
 
 fail2bansetup(){

--- a/onestopsecurity.sh
+++ b/onestopsecurity.sh
@@ -24,7 +24,7 @@ changesshport() {
     read -p "What port would you like to use for SSH (Ideally use an Ephemeral Port 32768-60999): " sshport
     #echo "Port $sshport" | sudo tee -a $sshconfig
     #This will replace the current port in the SSH config to the user input
-    sed -i "s/.*Port .*/Port $sshport/" $sshconfig
+    sudo sed -i "s/.*Port .*/Port $sshport/" $sshconfig
 }
 
 fail2bansetup(){

--- a/onestopsecurity.sh
+++ b/onestopsecurity.sh
@@ -8,14 +8,12 @@ sshport="22"
 
 #Functions
 update() {
-
     sudo apt-get update;
     sudo apt-get upgrade -y;
     sudo apt-get dist-upgrade -y;
 }
 
 housekeeping() {
-    
     sudo apt-get install mlocate -y;
     sudo apt-get autoremove -y;
     sudo apt-get autoclean -y;
@@ -33,27 +31,32 @@ fail2bansetup(){
     sudo cp /etc/fail2ban/jail.conf /etc/fail2ban/jail.local
     sudo systemctl start fail2ban
     sudo systemctl enable fail2ban
-    
 }
+
 fail2banwhitelist(){
     read -p "Enter your WAN IP (Find it here: https://duckduckgo.com/?q=ip ): " whitelistip
     sudo fail2ban-client set sshd addignoreip $whitelistip
 }
+
 ufwsetup(){
     sudo apt install ufw -y
     sudo ufw default deny incoming
     sudo ufw default allow outgoing
     sudo ufw allow $sshport/tcp
 }
+
 ufwportsetup(){
     echo "The SSH port default or custom has been allowed on the firewall."
     read -p "Please enter the port you would like to allow incomming: " porttoallow
     sudo ufw allow $porttoallow
-
     read -p "Would you like to add another port? (y/n) " additionalports
-
-
 }
+
+disableicmp(){
+    sudo sed -i '/ufw-before-input.*icmp/s/ACCEPT/DROP/g' /etc/ufw/before.rules
+    echo "- ICMP now disabled -"
+}
+
 restartservices() {
     sudo systemctl restart ssh
     sudo ufw enable
@@ -64,8 +67,7 @@ restartservices() {
 #Intro
 echo 'OneStopSecurity'
 echo 'Lets get started, there is no time to waste!'
-echo ' '
-
+echo
 echo '--------Update and Upgrade--------'
 read -p "Before we start, do you want to update all packages? (update, upgrade, dist-upgrade, autoremove, autoclean, updatedb, mlocate) (y/n): " updateanswer
  
@@ -77,12 +79,10 @@ if [ "$updateanswer" != "${updateanswer#[Yy]}" ]; then
     echo 
 fi
 
-
 echo 
 echo '--------SSH--------'
 echo 'To reduce the risk of automated (bot) attacks, it is good practice to change the SSH port from 22.'
 read -p "Do you want to change the SSH port? (y/n): " sshanswer
-
 
 if [ "$sshanswer" != "${sshanswer#[Yy]}" ]; then
 
@@ -96,15 +96,16 @@ if [ "$sshanswer" != "${sshanswer#[Yy]}" ]; then
 
 fi
 
-
 echo 
 echo '--------Fail2ban--------'
 echo 'Fail2Ban is an intrusion prevention software framework that protects computer servers from brute-force attacks. - https://www.fail2ban.org'
 read -p "Do you want to install Fail2ban? (y/n): " fail2bananswer
+
 if [ "$fail2bananswer" != "${fail2bananswer#[Yy]}" ]; 
     then
     fail2bansetup
 fi
+
 echo 
     read -p "Would you like to whitelist an IP on fail2ban (y/n): " fail2banwhitelistanswer
     if [ "$fail2banwhitelistanswer" != "${fail2banwhitelistanswer#[Yy]}" ]; 
@@ -118,10 +119,12 @@ echo 'UFW (Uncomplicated Firewall) is a popular firewall software for blocking p
 echo 'More info can be found here https://en.wikipedia.org/wiki/Uncomplicated_Firewall and here https://www.linux.com/training-tutorials/introduction-uncomplicated-firewall-ufw/'
 echo 'This is setup to block everything incomming by default (You can allow ports via this program) and allow everything outgoing'
 read -p "Do you want to install UFW? (y/n): " ufwanswer
+
 if [ "$ufwanswer" != "${ufwanswer#[Yy]}" ]; 
     then
     ufwsetup
 fi
+
 echo
 read -p "Would you like to allow any additional ports? (y/n): " additionalports
 while [ "$additionalports" != "${additionalports#[Yy]}" ]; 
@@ -129,15 +132,21 @@ while [ "$additionalports" != "${additionalports#[Yy]}" ];
     ufwportsetup
 done
 
+read -p "Would you like to disable ICMP traffic (You will not be able to ping this server) (y/n): " disableicmpanswer
+if [ "$disableicmpanswer" != "${disableicmpanswer#[Yy]}" ]; 
+    then
+    disableicmp
+fi
+
 echo
 echo '--------Unattended Upgrades--------'
 echo 'The purpose of unattended-upgrades is to keep the computer current with the latest security (and other) updates automatically. '
 read -p "Would you like to install unattended-upgrades? (y/n): " unattendedupgradesanswer
+
 if [ "$unattendedupgradesanswer" != "${unattendedupgradesanswer#[Yy]}" ]; 
     then
     sudo apt install unattended-upgrades -y
 fi
-
 
 if [ "$sshanswer" != "${sshanswer#[Yy]}" ]; 
     then

--- a/onestopsecurity.sh
+++ b/onestopsecurity.sh
@@ -60,8 +60,8 @@ disableicmp(){
 restartservices() {
     sudo systemctl restart ssh
     sudo ufw enable
+    sudo ufw reload
     sudo ufw status
-
 }
 
 #Intro


### PR DESCRIPTION
The bug fixed meant if the script was run twice with different SSH ports, both ports would be opened for SSH.

This has been fixed by replacing: 
`echo "Port $sshport" | sudo tee -a $sshconfig` to `sed -i "s/.*Port .*/Port $sshport/" $sshconfig`

Instead of adding a new line to the SSH config, sed has been used to replace the line preventing any duplicate entries.